### PR TITLE
adding fireworks demo for alcf 

### DIFF
--- a/FireWorks/ALCF/PBS_template.txt
+++ b/FireWorks/ALCF/PBS_template.txt
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+#PBS -l mppwidth=$${mppwidth}
+#PBS -l nodes=$${nnodes}:ppn=$${ppnode}
+#PBS -l walltime=$${walltime}
+#PBS -q $${queue}
+#PBS -A $${account}
+#PBS -G $${group_name}
+#PBS -N $${job_name}
+#PBS -o FW_job.out
+#PBS -e FW_job.error
+#PBS -V $${env}
+#PBS -M $${email} -m $${notification_options}
+#PBS -l pmem=$${pmem}
+#PBS -l filesystems=$${filesystems}
+
+$${pre_rocket}
+cd $${launch_dir}
+$${rocket_launch}
+$${post_rocket}
+
+# CommonAdapter (PBS) completed writing Template

--- a/FireWorks/ALCF/README_running_demo.md
+++ b/FireWorks/ALCF/README_running_demo.md
@@ -1,0 +1,243 @@
+# FireWorks demo at ALCF
+
+We'll provide instructions for running two similar versions
+of the same demo.
+
+Demo 1- a "high throughput" version of the demo in which
+every task in the workflow uses the same amount of compute
+resources (2 CPU nodes).
+
+Demo 2- a "heterogenous workflow" version of the demo
+in which one task in the workflow uses more resources
+than the others (1 CPU node, 2 CPU nodes, 1 CPU node).
+
+## About the demos
+
+We're using the open source
+[Diabetes dataset](https://scikit-learn.org/stable/datasets/toy_dataset.html#diabetes-dataset)
+that comes pre-installed in the `scikit-learn` package.
+We'll try to determine which attribute is the greatest
+risk factor for the progression of diabetes. 
+
+- `step_1_diabetes_preprocessing.py`: we load the diabetes dataset,
+  write it to two numpy `.npy` files.
+- `step_2_diabetes_correlation.py`: we load the `.npy` files and
+  process each attribute in a separate MPI rank across 2 nodes.
+  We calculate the Pearson correlation coefficient between each
+  attribute and the measure of disease progression. We gather
+  the outputs back to a single file.
+- `step_3_diabetes_postprocessing.py`: we load the Pearson correlation
+  coefficient data and pretty print it to the screen using pandas.
+
+## Demo 1- high throughput
+
+In this version of the demo, steps 1, 2, and 3 will all use the 
+same amount of resources (2 CPU nodes). FireWorks is a bit more
+natually suited to this kind of workflow and requires less configuration
+so we'll start here. 
+
+Let's start by looking at our high-throughput FireWork:
+
+```
+(2022-09-08/fireworks) stephey@polaris-login-01:~/DOE-HPC-workflow-training/FireWorks/ALCF> cat fw_diabetes_ht.yaml 
+
+fws:
+- fw_id: 1
+  spec:
+    _category: twonode
+    _launch_dir: /home/stephey/DOE-HPC-workflow-training/FireWorks/ALCF
+    _tasks:
+    - _fw_name: ScriptTask
+      script: mpiexec -n 1 python step_1_diabetes_preprocessing.py
+- fw_id: 2
+  spec:
+    _category: twonode
+    _launch_dir: /home/stephey/DOE-HPC-workflow-training/FireWorks/ALCF
+    _tasks:
+    - _fw_name: ScriptTask
+      script: mpiexec -n 10 python step_2_diabetes_correlation.py
+- fw_id: 3
+  spec:
+    _category: twonode
+    _launch_dir: /home/stephey/DOE-HPC-workflow-training/FireWorks/ALCF
+    _tasks:
+    - _fw_name: ScriptTask
+      script: mpiexec -n 1 python step_3_diabetes_postprocessing.py
+links:
+  1:
+  - 2
+  2:
+  - 3
+metadata: {}
+```
+
+Note: you'll need to change the location of the `_launch_dir`
+to your own directory.
+
+Things to note:
+- We specify the `_category` key to match our task to the right worker resources.
+- We specify the `_launch_dir` so that each FireWork will run in this directory.
+  This is important since we are passing files between workflow steps. Unfortunately
+  we cannot use any bash shortcuts here- we have to specify the absolute path.
+- We specify the task dependencies in the `links` section (2 depends on 1,
+  3 depends on 2). 
+
+Next, let's look at our `my_fworker2.yaml`. This is the worker configuration
+file that will match the `_category: twonode` key in our spec.
+
+```
+(2022-09-08/fireworks) stephey@polaris-login-01:~/DOE-HPC-workflow-training/FireWorks/ALCF> cat my_fworker2.yaml 
+name: two node fireworker
+category: twonode
+query: '{}'
+```
+
+Next, let's look at our `my_qadapter.yaml`. On ALCF Polaris we use a PBS adapter- on other systems, you can
+substitue the [appropriate adapter](https://github.com/materialsproject/fireworks/tree/bd2bb5078122fa27a7dda2084abb3af8cac05436/fw_tutorials/queue).
+
+Note that Polaris-specific changes to the PBS adapter haven't been
+[merged](https://github.com/materialsproject/fireworks/pull/498) upstream, so for now
+you'll need to modify the PBS template in your conda installation.
+
+This file is located at `$CONDA_PREFIX/lib/python3.9/site-packages/fireworks/user_objects/queue_adapters/PBS_template.txt`
+
+The modification you need to make is to add the `filesystems` PBS queue option immediately below
+`#PBS -l pmem=$${pmem}` like so
+
+```
+#PBS -l pmem=$${pmem}
+#PBS -l filesystems=$${filesystems}
+```
+
+Save your changes and exit.
+
+Now that your PBS template is ready, let's take a look at our `my_qadapter.yaml`. Note you'll need
+to change the paths to reflect your own setup.
+
+```
+(2022-09-08/fireworks) stephey@polaris-login-01:~/DOE-HPC-workflow-training/FireWorks/ALCF> cat my_qadapter.yaml
+_fw_name: CommonAdapter
+_fw_q_type: PBS
+rocket_launch: rlaunch -l /home/stephey/DOE-HPC-workflow-training/FireWorks/ALCF/my_launchpad.yaml -w /home/stephey/DOE-HPC-workflow-training/FireWorks/ALCF/my_fworker2.yaml singleshot
+nnodes: 2
+ppnode: 1
+walltime: '00:05:00'
+queue: debug-scaling
+account: WALSforAll
+filesystems: home:eagle
+job_name: null
+logdir: /home/stephey/DOE-HPC-workflow-training/FireWorks/ALCF/
+pre_rocket: module load conda; conda activate fireworks
+post_rocket: null
+```
+
+Things to note:
+- We unfortuatnely have to specify the full paths
+  to `my_launchpad.yaml` and `my_fworker2.yaml`- bash shortcuts
+  are not supported.
+- We have specified `singleshot` here, since each task within the workflow only needs to run once.
+- We have specified the usual Slurm job resources that each task will use.
+- Since PBS does not inherit the environment which we used to launch the job,
+  we'll need to load our custom conda environment before each job runs.  
+
+Now that we've examined all the pieces, let's run our FireWorks workflow.
+
+We will launch the workflow with `qlaunch rapidfire`. Remember that we have
+specified `rlaunch singleshot` in our queue adapter- this will run each task once per job.
+However we need to launch 3 jobs, one for each task. For this reason we use `qlaunch rapidfire`
+to automatically launch our whole workflow. `rapidfile` will keep launching jobs until
+there are no more pending FireWorks in the database.
+
+Due to [queue restrictions](https://docs.alcf.anl.gov/polaris/running-jobs/)
+on Polaris, we will use `qlaunch rapidfire -m 1` to launch one job at a time
+since we are using the `debug-scaling` queue. Other queues may not need this
+restriction. 
+
+```
+(2022-09-08/fireworks) stephey@polaris-login-02:~/DOE-HPC-workflow-training/FireWorks/ALCF> qlaunch rapidfire -m 1
+2023-04-11 00:38:09,568 INFO getting queue adapter
+2023-04-11 00:38:09,570 INFO Created new dir /home/stephey/DOE-HPC-workflow-training/FireWorks/ALCF/block_2023-04-11-00-38-09-569570
+2023-04-11 00:38:09,655 INFO The number of jobs currently in the queue is: 0
+2023-04-11 00:38:09,656 INFO 0 jobs in queue. Maximum allowed by user: 1
+2023-04-11 00:38:09,688 INFO Launching a rocket!
+2023-04-11 00:38:09,695 INFO Created new dir /home/stephey/DOE-HPC-workflow-training/FireWorks/ALCF/block_2023-04-11-00-38-09-569570/launcher_2023-04-11-00-38-09-694941
+2023-04-11 00:38:09,695 INFO moving to launch_dir /home/stephey/DOE-HPC-workflow-training/FireWorks/ALCF/block_2023-04-11-00-38-09-569570/launcher_2023-04-11-00-38-09-694941
+2023-04-11 00:38:09,698 INFO submitting queue script
+2023-04-11 00:38:09,939 INFO Job submission was successful and job_id is 477639
+2023-04-11 00:38:09,939 INFO Sleeping for 5 seconds...zzz...
+2023-04-11 00:38:14,951 INFO Jobs in queue (1) meets/exceeds maximum allowed (1)
+2023-04-11 00:38:14,956 INFO Finished a round of launches, sleeping for 60 secs
+2023-04-11 00:39:15,016 INFO Checking for Rockets to run...
+2023-04-11 00:39:15,072 INFO The number of jobs currently in the queue is: 0
+2023-04-11 00:39:15,073 INFO 0 jobs in queue. Maximum allowed by user: 1
+2023-04-11 00:39:15,080 INFO Launching a rocket!
+2023-04-11 00:39:15,087 INFO Created new dir /home/stephey/DOE-HPC-workflow-training/FireWorks/ALCF/block_2023-04-11-00-38-09-569570/launcher_2023-04-11-00-39-15-086463
+2023-04-11 00:39:15,087 INFO moving to launch_dir /home/stephey/DOE-HPC-workflow-training/FireWorks/ALCF/block_2023-04-11-00-38-09-569570/launcher_2023-04-11-00-39-15-086463
+2023-04-11 00:39:15,090 INFO submitting queue script
+2023-04-11 00:39:15,330 INFO Job submission was successful and job_id is 477640
+2023-04-11 00:39:15,331 INFO Sleeping for 5 seconds...zzz...
+2023-04-11 00:39:20,343 INFO Jobs in queue (1) meets/exceeds maximum allowed (1)
+2023-04-11 00:39:20,348 INFO Finished a round of launches, sleeping for 60 secs
+2023-04-11 00:40:20,408 INFO Checking for Rockets to run...
+2023-04-11 00:40:20,464 INFO The number of jobs currently in the queue is: 0
+2023-04-11 00:40:20,464 INFO 0 jobs in queue. Maximum allowed by user: 1
+2023-04-11 00:40:20,473 INFO Launching a rocket!
+2023-04-11 00:40:20,480 INFO Created new dir /home/stephey/DOE-HPC-workflow-training/FireWorks/ALCF/block_2023-04-11-00-38-09-569570/launcher_2023-04-11-00-40-20-479394
+2023-04-11 00:40:20,480 INFO moving to launch_dir /home/stephey/DOE-HPC-workflow-training/FireWorks/ALCF/block_2023-04-11-00-38-09-569570/launcher_2023-04-11-00-40-20-479394
+2023-04-11 00:40:20,483 INFO submitting queue script
+2023-04-11 00:40:20,763 INFO Job submission was successful and job_id is 477641
+2023-04-11 00:40:20,764 INFO Sleeping for 5 seconds...zzz...
+2023-04-11 00:40:25,776 INFO Jobs in queue (1) meets/exceeds maximum allowed (1)
+2023-04-11 00:40:25,780 INFO Finished a round of launches, sleeping for 60 secs
+2023-04-11 00:41:25,840 INFO Checking for Rockets to run...
+2023-04-11 00:41:25,895 INFO The number of jobs currently in the queue is: 0
+2023-04-11 00:41:25,895 INFO 0 jobs in queue. Maximum allowed by user: 1
+```
+
+We can query the status of our workflow in another terminal. After a few minutes
+you should see
+
+```
+(2022-09-08/fireworks) stephey@polaris-login-01:~/DOE-HPC-workflow-training/FireWorks/ALCF> lpad get_fws
+[
+    {
+        "fw_id": 1,
+        "created_on": "2023-04-11T00:37:59.961412",
+        "updated_on": "2023-04-11T00:38:20.326142",
+        "state": "COMPLETED",
+        "name": "Unnamed FW"
+    },
+    {
+        "fw_id": 2,
+        "created_on": "2023-04-11T00:37:59.961634",
+        "updated_on": "2023-04-11T00:39:25.305963",
+        "state": "COMPLETED",
+        "name": "Unnamed FW"
+    },
+    {
+        "fw_id": 3,
+        "created_on": "2023-04-11T00:37:59.961775",
+        "updated_on": "2023-04-11T00:40:30.423533",
+        "state": "COMPLETED",
+        "name": "Unnamed FW"
+    }
+]
+```
+
+FireWorks lists all of our tasks as successfully completed.
+
+Let's take a look in our `block_<date>` directory to see what
+FireWorks did. Note that in this directory, there may be more
+`launcher_<date>` directories than steps in our workflow.
+This is because FireWorks has no visibility into the current
+state of the queue- it just launches jobs every minute
+while the database reports there are pending workflow steps.
+
+## Demo 2- heterogenous workflow
+
+Let's make things a little more complicated now. In this version of the demo,
+we'll have a workflow where step 1 and step 3 only use one node, but step 2
+uses two nodes.
+
+
+

--- a/FireWorks/ALCF/fw_diabetes_ht.yaml
+++ b/FireWorks/ALCF/fw_diabetes_ht.yaml
@@ -1,0 +1,29 @@
+
+fws:
+- fw_id: 1
+  spec:
+    _category: twonode
+    _launch_dir: /home/stephey/DOE-HPC-workflow-training/FireWorks/ALCF
+    _tasks:
+    - _fw_name: ScriptTask
+      script: mpiexec -n 1 python step_1_diabetes_preprocessing.py
+- fw_id: 2
+  spec:
+    _category: twonode
+    _launch_dir: /home/stephey/DOE-HPC-workflow-training/FireWorks/ALCF
+    _tasks:
+    - _fw_name: ScriptTask
+      script: mpiexec -n 10 python step_2_diabetes_correlation.py
+- fw_id: 3
+  spec:
+    _category: twonode
+    _launch_dir: /home/stephey/DOE-HPC-workflow-training/FireWorks/ALCF
+    _tasks:
+    - _fw_name: ScriptTask
+      script: mpiexec -n 1 python step_3_diabetes_postprocessing.py
+links:
+  1:
+  - 2
+  2:
+  - 3
+metadata: {}

--- a/FireWorks/ALCF/fw_diabetes_wf.yaml
+++ b/FireWorks/ALCF/fw_diabetes_wf.yaml
@@ -1,0 +1,28 @@
+fws:
+- fw_id: 1
+  spec:
+    _category: onenode
+    _launch_dir: /home/stephey/DOE-HPC-workflow-training/FireWorks/ALCF 
+    _tasks:
+    - _fw_name: ScriptTask
+      script: mpiexec -n 1 python step_1_diabetes_preprocessing.py
+- fw_id: 2
+  spec:
+    _category: twonode
+    _launch_dir: /home/stephey/DOE-HPC-workflow-training/FireWorks/ALCF
+    _tasks:
+    - _fw_name: ScriptTask
+      script: mpiexec -n 10 python step_2_diabetes_correlation.py
+- fw_id: 3
+  spec:
+    _category: onenode
+    _launch_dir: /home/stephey/DOE-HPC-workflow-training/FireWorks/ALCF
+    _tasks:
+    - _fw_name: ScriptTask
+      script: mpiexec -n 1 python step_3_diabetes_postprocessing.py
+links:
+  1:
+  - 2
+  2:
+  - 3
+metadata: {}

--- a/FireWorks/ALCF/my_fworker1.yaml
+++ b/FireWorks/ALCF/my_fworker1.yaml
@@ -1,0 +1,3 @@
+name: one node fireworker
+category: onenode
+query: '{}'

--- a/FireWorks/ALCF/my_fworker2.yaml
+++ b/FireWorks/ALCF/my_fworker2.yaml
@@ -1,0 +1,3 @@
+name: two node fireworker
+category: twonode
+query: '{}'

--- a/FireWorks/ALCF/my_qadapter.yaml
+++ b/FireWorks/ALCF/my_qadapter.yaml
@@ -1,0 +1,13 @@
+_fw_name: CommonAdapter
+_fw_q_type: PBS
+rocket_launch: rlaunch -l /home/stephey/DOE-HPC-workflow-training/FireWorks/ALCF/my_launchpad.yaml -w /home/stephey/DOE-HPC-workflow-training/FireWorks/ALCF/my_fworker2.yaml singleshot
+nnodes: 2
+ppnode: 1
+walltime: '00:05:00'
+queue: debug-scaling
+account: WALSforAll
+filesystems: home:eagle
+job_name: null
+logdir: /home/stephey/DOE-HPC-workflow-training/FireWorks/ALCF/
+pre_rocket: module load conda; conda activate fireworks
+post_rocket: null

--- a/FireWorks/ALCF/my_qadapter1.yaml
+++ b/FireWorks/ALCF/my_qadapter1.yaml
@@ -1,0 +1,13 @@
+_fw_name: CommonAdapter
+_fw_q_type: PBS
+rocket_launch: rlaunch -l /home/stephey/DOE-HPC-workflow-training/FireWorks/ALCF/my_launchpad.yaml -w /home/stephey/DOE-HPC-workflow-training/FireWorks/ALCF/my_fworker1.yaml singleshot
+nnodes: 1
+ppnode: 1
+walltime: '00:05:00'
+queue: preemptable
+account: WALSforAll
+filesystems: home:eagle
+job_name: null
+logdir: /home/stephey/DOE-HPC-workflow-training/FireWorks/ALCF/
+pre_rocket: module load conda; conda activate fireworks
+post_rocket: null

--- a/FireWorks/ALCF/my_qadapter2.yaml
+++ b/FireWorks/ALCF/my_qadapter2.yaml
@@ -1,0 +1,13 @@
+_fw_name: CommonAdapter
+_fw_q_type: PBS
+rocket_launch: rlaunch -l /home/stephey/DOE-HPC-workflow-training/FireWorks/ALCF/my_launchpad.yaml -w /home/stephey/DOE-HPC-workflow-training/FireWorks/ALCF/my_fworker2.yaml singleshot
+nnodes: 2
+ppnode: 1
+walltime: '00:05:00'
+queue: preemptable
+account: WALSforAll
+filesystems: home:eagle
+job_name: null
+logdir: /home/stephey/DOE-HPC-workflow-training/FireWorks/ALCF/
+pre_rocket: module load conda; conda activate fireworks
+post_rocket: null

--- a/FireWorks/ALCF/step_1_diabetes_preprocessing.py
+++ b/FireWorks/ALCF/step_1_diabetes_preprocessing.py
@@ -1,0 +1,56 @@
+#!/usr/bin/python3
+
+import numpy as np
+import pandas as pd
+from sklearn.datasets import load_diabetes
+
+#load public diabetes dataset
+x_diabetes, y_diabetes = load_diabetes(return_X_y=True)
+
+#dataset info on the docs page: https://scikit-learn.org/stable/datasets/toy_dataset.html#diabetes-dataset
+#https://www4.stat.ncsu.edu/~boos/var.select/diabetes.html
+
+#Note: Each of these 10 feature variables have been mean centered and scaled by the standard deviation
+#times the square root of n_samples (i.e. the sum of squares of each column totals 1).
+
+# Number of Instances:
+
+#     442
+# Number of Attributes:
+
+#     First 10 columns are numeric predictive values
+# Target:
+
+#     Column 11 is a quantitative measure of disease progression one year after baseline
+# Attribute Information:
+
+#         age age in years
+
+#         sex
+
+#         bmi body mass index
+
+#         bp average blood pressure
+
+#         s1 tc, total serum cholesterol
+
+#         s2 ldl, low-density lipoproteins
+
+#         s3 hdl, high-density lipoproteins
+
+#         s4 tch, total cholesterol / HDL
+
+#         s5 ltg, possibly log of serum triglycerides level
+
+#         s6 glu, blood sugar level
+
+# take a look at the data, but remember it has been mean centered and scaled
+print(pd.DataFrame(x_diabetes).describe())
+
+# save attributes
+np.save('x_diabetes', x_diabetes)
+print("wrote x_diabetes file")
+
+# save disease progression measure
+np.save('y_diabetes', y_diabetes)
+print("wrote y_diabetes file")

--- a/FireWorks/ALCF/step_2_diabetes_correlation.py
+++ b/FireWorks/ALCF/step_2_diabetes_correlation.py
@@ -1,0 +1,51 @@
+#!/usr/bin/python3
+
+"""
+this script will read from numpy data files written in step 1
+each mpi rank will select one column of the dataset for
+which to compute the pearson correlation coefficient
+with the disease progression metric
+the goal is to calculate the correlation cofficients
+of each attribute in the dataset with the final
+disase progression metric
+note this is way overkill for this small dataset, but the idea
+is to simulate a real parallel analysis task
+"""
+
+import numpy as np
+from mpi4py import MPI
+import socket
+
+comm = MPI.COMM_WORLD
+size = comm.Get_size()
+rank = comm.Get_rank()
+
+#verify we're running multinode
+print('hostnames:', socket.gethostname())
+
+# each rank should load the attribute data that we wrote in step 1
+x_diabetes = np.load('x_diabetes.npy')
+
+# each rank should load the disease progression measure that we wrote in step 1
+y_diabetes = np.load('y_diabetes.npy')
+
+# each rank should select the column for which it will compute the pearson correlation coefficient
+attribute = x_diabetes[:, rank]
+
+# compute the pearson correlation coefficient
+p_corr_coeff = np.corrcoef(attribute, y_diabetes)[1][0]
+
+# now need to collect the correlation coefficients back at rank 0 to write to a single file
+all_coeffs = None
+if rank == 0:
+    all_coeffs = np.empty([size], dtype='float64')
+comm.Gather(p_corr_coeff, all_coeffs, root=0)
+
+# sanity check
+if rank == 0:
+    print(all_coeffs)
+
+# save output file
+if rank == 0:
+    np.save('all_coeffs', all_coeffs)
+    print("wrote all_coeffs file")

--- a/FireWorks/ALCF/step_3_diabetes_postprocessing.py
+++ b/FireWorks/ALCF/step_3_diabetes_postprocessing.py
@@ -1,0 +1,31 @@
+#!/usr/bin/python3
+
+"""
+diabetes postprocessing
+"""
+
+import numpy as np
+import pandas as pd
+
+all_coeffs = np.load('all_coeffs.npy')
+
+#put results into dict with attribute as key
+
+results = dict()
+results['age'] = [all_coeffs[0]]
+results['sex'] = [all_coeffs[1]]
+results['body_mass_index'] = [all_coeffs[2]]
+results['blood_pressure'] = [all_coeffs[3]]
+results['total_cholesterol'] = [all_coeffs[4]]
+results['ldl_cholesterol'] = [all_coeffs[5]]
+results['hdl_cholesterol'] = [all_coeffs[6]]
+results['total/hdl_cholesterol'] = [all_coeffs[7]]
+results['log_of_serum_triglycerides'] = [all_coeffs[8]]
+results['blood_sugar_level'] = [all_coeffs[9]]
+
+df = pd.DataFrame.from_dict(results)
+
+# print to terminal
+
+print("pearson correlation coefficients for each attribute")
+print(df.transpose().head(10))


### PR DESCRIPTION
Adds a FireWorks demo for ALCF that is very similar to the NERSC CLI demo

Changes compared to the NERSC version:
- We have to limit the rapidfire command to avoid exceeding the Polaris queue policies
- We have to do some work to source the FireWorks env inside the worker since PBS doesn't inherit the environment
- We have to manually modify the PBS queue adapter since the current adapter doesn't have the `filesystems` field. I submitted a [PR](https://github.com/materialsproject/fireworks/pull/498) but it won't make it into a release before the workshop. 